### PR TITLE
Delete some debugging println()'s.

### DIFF
--- a/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
+++ b/modules/scala/scala-interpreter/src/main/scala/almond/ScalaInterpreter.scala
@@ -483,8 +483,6 @@ final class ScalaInterpreter(
       code
     )
 
-    println(other.mkString("\n") + "\n")
-
     val completions = completions0
       .filter(!_.contains("$"))
       .filter(_.nonEmpty)


### PR DESCRIPTION
Finally figured out why my console was scrolling away every time I tab-completed something.

I'm assuming these were an accidental addition.